### PR TITLE
Add missing Jest setup file

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add root `jest.setup.js` so Jest doesn't look for a missing setup file

## Testing
- `npm install`
- `npm test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4e5e72b48326961487dd85462827