### PR TITLE
Add vehicle routing optimization endpoint and dashboard

### DIFF
--- a/Backend/src_ai/routing/index.ts
+++ b/Backend/src_ai/routing/index.ts
@@ -1,0 +1,59 @@
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+export interface Location {
+  latitude: number;
+  longitude: number;
+}
+
+export interface DonationLocation {
+  id: string;
+  location: Location;
+}
+
+export interface VolunteerInfo {
+  id: string;
+  isActive: boolean;
+  availability: { days: string[]; times: string[] };
+  currentLocation: Location;
+}
+
+export interface OptimizeRoutesInput {
+  donations: DonationLocation[];
+  volunteers: VolunteerInfo[];
+  currentDay: string;
+  currentTime: string;
+  trafficFactor?: number;
+}
+
+export interface RouteStop {
+  donationId: string;
+  location: Location;
+}
+
+export interface RoutePlan {
+  volunteerId: string;
+  stops: RouteStop[];
+  distance_km: number;
+}
+
+export interface OptimizeRoutesOutput {
+  routes: RoutePlan[];
+  unassigned: string[];
+}
+
+export function optimizeRoutes(input: OptimizeRoutesInput): OptimizeRoutesOutput {
+  const script = path.join(__dirname, 'optimize_routes.py');
+  const result = spawnSync('python3', [script, JSON.stringify(input)], {
+    encoding: 'utf-8',
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    console.error(result.stderr);
+    throw new Error('route optimization failed');
+  }
+  return JSON.parse(result.stdout.trim() || '{}');
+}
+

--- a/Backend/src_ai/routing/optimize_routes.py
+++ b/Backend/src_ai/routing/optimize_routes.py
@@ -1,0 +1,100 @@
+import json
+import math
+import sys
+from typing import Any, Dict, List
+
+from ortools.constraint_solver import pywrapcp, routing_enums_pb2
+
+
+def distance(a: Dict[str, float], b: Dict[str, float]) -> int:
+    dx = a["latitude"] - b["latitude"]
+    dy = a["longitude"] - b["longitude"]
+    return int(math.sqrt(dx * dx + dy * dy) * 111000)
+
+
+def available(vol: Dict[str, Any], day: str, time: str) -> bool:
+    if not vol.get("isActive"):
+        return False
+    avail = vol.get("availability", {})
+    return day in avail.get("days", []) and time in avail.get("times", [])
+
+
+def build_distance_matrix(locations: List[Dict[str, float]], factor: float) -> List[List[int]]:
+    matrix = []
+    for a in locations:
+        row = []
+        for b in locations:
+            row.append(int(distance(a, b) * factor))
+        matrix.append(row)
+    return matrix
+
+
+def optimize(data: Dict[str, Any]) -> Dict[str, Any]:
+    donations = data.get("donations", [])
+    day = data.get("currentDay")
+    time = data.get("currentTime")
+    traffic = float(data.get("trafficFactor", 1.0))
+    volunteers = [v for v in data.get("volunteers", []) if available(v, day, time)]
+
+    if not donations or not volunteers:
+        return {"routes": [], "unassigned": [d["id"] for d in donations]}
+
+    all_nodes = [v["currentLocation"] for v in volunteers] + [d["location"] for d in donations]
+    distance_matrix = build_distance_matrix(all_nodes, traffic)
+
+    num_vehicles = len(volunteers)
+    starts = list(range(num_vehicles))
+    ends = list(range(num_vehicles))
+
+    manager = pywrapcp.RoutingIndexManager(len(distance_matrix), num_vehicles, starts, ends)
+    routing = pywrapcp.RoutingModel(manager)
+
+    def dist_callback(from_index: int, to_index: int) -> int:
+        return distance_matrix[manager.IndexToNode(from_index)][manager.IndexToNode(to_index)]
+
+    transit_cb = routing.RegisterTransitCallback(dist_callback)
+    routing.SetArcCostEvaluatorOfAllVehicles(transit_cb)
+
+    def demand_callback(from_index: int) -> int:
+        node = manager.IndexToNode(from_index)
+        return 0 if node < num_vehicles else 1
+
+    demand_cb = routing.RegisterUnaryTransitCallback(demand_callback)
+    routing.AddDimensionWithVehicleCapacity(demand_cb, 0, [3] * num_vehicles, True, "Capacity")
+
+    search_params = pywrapcp.DefaultRoutingSearchParameters()
+    search_params.first_solution_strategy = routing_enums_pb2.FirstSolutionStrategy.PATH_CHEAPEST_ARC
+
+    solution = routing.SolveWithParameters(search_params)
+
+    routes = []
+    if solution:
+        assigned = set()
+        for v in range(num_vehicles):
+            index = routing.Start(v)
+            stops = []
+            dist = 0
+            while not routing.IsEnd(index):
+                prev = index
+                index = solution.Value(routing.NextVar(index))
+                node = manager.IndexToNode(index)
+                if node >= num_vehicles:
+                    donation_idx = node - num_vehicles
+                    donation = donations[donation_idx]
+                    stops.append({"donationId": donation["id"], "location": donation["location"]})
+                    assigned.add(donation["id"])
+                dist += routing.GetArcCostForVehicle(prev, index, v)
+            routes.append({"volunteerId": volunteers[v]["id"], "stops": stops, "distance_km": dist / 1000})
+        unassigned = [d["id"] for d in donations if d["id"] not in assigned]
+    else:
+        routes = []
+        unassigned = [d["id"] for d in donations]
+
+    return {"routes": routes, "unassigned": unassigned}
+
+
+if __name__ == "__main__":
+    input_data = json.loads(sys.argv[1])
+    result = optimize(input_data)
+    print(json.dumps(result))
+

--- a/Frontend/src_app/api/routes/optimize/route.ts
+++ b/Frontend/src_app/api/routes/optimize/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { mockDonations, mockVolunteers } from '@/lib/data';
+import type { DayOfWeek, TimeOfDay } from '@/lib/types';
+import { optimizeRoutes } from '../../../../Backend/src_ai/routing';
+
+function currentTimeOfDay(): TimeOfDay {
+  const h = new Date().getHours();
+  if (h < 12) return 'Morning';
+  if (h < 18) return 'Afternoon';
+  return 'Evening';
+}
+
+export async function GET() {
+  const day = new Date().toLocaleDateString('en-US', { weekday: 'long' }) as DayOfWeek;
+  const time = currentTimeOfDay();
+
+  const result = optimizeRoutes({
+    donations: mockDonations.filter((d) => d.status === 'Available').map((d) => ({
+      id: d.id,
+      location: d.location,
+    })),
+    volunteers: mockVolunteers.map((v) => ({
+      id: v.id,
+      isActive: v.isActive,
+      availability: v.availability,
+      currentLocation: v.currentLocation!,
+    })),
+    currentDay: day,
+    currentTime: time,
+    trafficFactor: 1.2,
+  });
+
+  return NextResponse.json(result);
+}
+

--- a/Frontend/src_app/volunteer/dashboard/page.tsx
+++ b/Frontend/src_app/volunteer/dashboard/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+import { useEffect, useState } from "react";
+
+interface RouteStop {
+  donationId: string;
+  location: { latitude: number; longitude: number };
+}
+
+interface RoutePlan {
+  volunteerId: string;
+  stops: RouteStop[];
+  distance_km: number;
+}
+
+export default function VolunteerDashboardPage() {
+  const [routes, setRoutes] = useState<RoutePlan[]>([]);
+
+  const fetchRoutes = () =>
+    fetch("/api/routes/optimize")
+      .then((res) => res.json())
+      .then((data) => setRoutes(data.routes || []));
+
+  useEffect(() => {
+    fetchRoutes();
+    const id = setInterval(fetchRoutes, 60000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="container mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">Volunteer Routes</h1>
+      {routes.map((r) => (
+        <div key={r.volunteerId} className="border rounded p-2">
+          <h2 className="font-semibold">Volunteer {r.volunteerId}</h2>
+          <ul className="list-disc pl-4">
+            {r.stops.map((s) => (
+              <li key={s.donationId}>
+                Pickup donation {s.donationId} at ({s.location.latitude.toFixed(3)},{" "}
+                {s.location.longitude.toFixed(3)})
+              </li>
+            ))}
+          </ul>
+          <p className="text-sm text-gray-500">
+            Estimated distance: {r.distance_km.toFixed(2)} km
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/Frontend/src_lib/nav-links.ts
+++ b/Frontend/src_lib/nav-links.ts
@@ -43,6 +43,12 @@ export const mainNavLinks: NavLink[] = [
     tooltip: "Donor Dashboard (D)",
   },
   {
+    href: "/volunteer/dashboard",
+    label: "Volunteer Hub",
+    icon: LayoutDashboard,
+    tooltip: "Volunteer Dashboard",
+  },
+  {
     href: "/volunteer/signup",
     label: "Volunteer",
     icon: UserPlus,


### PR DESCRIPTION
## Summary
- create `routing` service in the backend powered by OR‑Tools
- expose `/api/routes/optimize` endpoint that calls the service
- add volunteer dashboard page that refreshes optimized routes
- show link to the new dashboard in the navigation menu

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_683f92d687e8832690aeccf55abb1d62