### PR TITLE
Integrate CV model for food analysis

### DIFF
--- a/Backend/src_ai/cv-model/predict.py
+++ b/Backend/src_ai/cv-model/predict.py
@@ -1,0 +1,42 @@
+import base64
+import json
+import sys
+from io import BytesIO
+
+import torch
+from PIL import Image
+import torchvision.transforms as T
+
+FOOD_LABELS = ["carrots", "apples", "bananas", "bread"]
+
+
+def preprocess(data_uri: str) -> torch.Tensor:
+    _, b64 = data_uri.split(',', 1)
+    img = Image.open(BytesIO(base64.b64decode(b64))).convert('RGB')
+    transform = T.Compose([T.Resize((224, 224)), T.ToTensor()])
+    return transform(img).unsqueeze(0)
+
+
+def predict(model_path: str, data_uri: str) -> dict:
+    model = torch.jit.load(model_path, map_location='cpu')
+    model.eval()
+    inp = preprocess(data_uri)
+    with torch.no_grad():
+        out = model(inp)[0]
+    cls = out[: len(FOOD_LABELS)].argmax().item()
+    weight = float(out[len(FOOD_LABELS)])
+    spoil = torch.sigmoid(out[len(FOOD_LABELS) + 1]).item() > 0.5
+    pack = torch.sigmoid(out[len(FOOD_LABELS) + 2]).item() > 0.5
+    return {
+        "foodType": FOOD_LABELS[cls],
+        "estimatedWeightKg": weight,
+        "spoilageDetected": spoil,
+        "packagingOk": pack,
+    }
+
+
+if __name__ == "__main__":
+    model = sys.argv[1]
+    uri = sys.argv[2]
+    result = predict(model, uri)
+    print(json.dumps(result))

--- a/Backend/src_ai/cv-model/train_food_image_model.py
+++ b/Backend/src_ai/cv-model/train_food_image_model.py
@@ -1,0 +1,83 @@
+import json
+import os
+from pathlib import Path
+from typing import List, Dict
+
+import torch
+import torchvision.transforms as T
+from torch.utils.data import DataLoader, Dataset
+from PIL import Image
+
+FOOD_LABELS = ["carrots", "apples", "bananas", "bread"]
+
+class FoodDataset(Dataset):
+    """Simple dataset expecting images in a directory and annotations.json mapping
+    filename to metadata.
+    {
+      "image1.jpg": {"food_type": "carrots", "weight_kg": 1.2, "spoiled": false, "packaging_ok": true}
+    }
+    """
+
+    def __init__(self, root: str, annotations: str) -> None:
+        self.root = Path(root)
+        with open(annotations, "r") as f:
+            data = json.load(f)
+        self.records: List[Dict] = [
+            {"path": self.root / name, **info} for name, info in data.items()
+        ]
+        self.transform = T.Compose([T.Resize((224, 224)), T.ToTensor()])
+
+    def __len__(self) -> int:
+        return len(self.records)
+
+    def __getitem__(self, idx: int):
+        rec = self.records[idx]
+        img = Image.open(rec["path"]).convert("RGB")
+        img = self.transform(img)
+        label = FOOD_LABELS.index(rec["food_type"])
+        weight = torch.tensor([rec["weight_kg"]], dtype=torch.float32)
+        spoilage = torch.tensor([float(rec["spoiled"])], dtype=torch.float32)
+        packaging = torch.tensor([float(rec["packaging_ok"])], dtype=torch.float32)
+        return img, label, weight, spoilage, packaging
+
+def build_model(num_classes: int):
+    model = torch.hub.load("pytorch/vision", "resnet18", pretrained=True)
+    model.fc = torch.nn.Linear(model.fc.in_features, num_classes + 3)
+    return model
+
+
+def train(data_dir: str, annotations: str, output: str = "food_image_model.pt") -> None:
+    ds = FoodDataset(data_dir, annotations)
+    loader = DataLoader(ds, batch_size=8, shuffle=True)
+    model = build_model(len(FOOD_LABELS))
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+    loss_fn = torch.nn.MSELoss()
+    for epoch in range(1):  # short demo training
+        for imgs, labels, weights, spoiled, packaging in loader:
+            pred = model(imgs)
+            cls_pred = pred[:, : len(FOOD_LABELS)]
+            weight_pred = pred[:, len(FOOD_LABELS) : len(FOOD_LABELS) + 1]
+            spoil_pred = pred[:, len(FOOD_LABELS) + 1 : len(FOOD_LABELS) + 2]
+            pack_pred = pred[:, len(FOOD_LABELS) + 2 :]
+            loss = (
+                torch.nn.functional.cross_entropy(cls_pred, labels)
+                + loss_fn(weight_pred.squeeze(), weights.squeeze())
+                + torch.nn.functional.binary_cross_entropy_with_logits(spoil_pred.squeeze(), spoiled.squeeze())
+                + torch.nn.functional.binary_cross_entropy_with_logits(pack_pred.squeeze(), packaging.squeeze())
+            )
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+    scripted = torch.jit.script(model)
+    scripted.save(output)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Train food image analysis model")
+    parser.add_argument("data_dir", help="Directory of training images")
+    parser.add_argument("annotations", help="Path to annotations JSON")
+    parser.add_argument("--output", default="food_image_model.pt", help="Output model path")
+    args = parser.parse_args()
+    train(args.data_dir, args.annotations, args.output)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ Run the scheduler locally with:
 npm run forecast:cron
 ```
 
+## 🖼️ Computer Vision Model
+
+Labeled food photos can be used to train a lightweight PyTorch model that estimates the food type, weight,
+and checks for spoilage or packaging issues. The training script lives in
+`Backend/src_ai/cv-model/train_food_image_model.py` and expects an image directory and
+an `annotations.json` file describing each image. After training, a scripted model is stored at
+`Backend/src_ai/cv-model/food_image_model.pt`.
+
+In production the API flow invokes `cv-model/predict.py` to analyze uploaded images and returns structured
+data like `{ "foodType": "carrots", "estimatedWeightKg": 2.0, "spoilageDetected": false, "packagingOk": true }`.
+
 2. **Install dependencies**
 
    ```bash


### PR DESCRIPTION
## Summary
- add training script for food image model using PyTorch
- provide placeholder CV model and Python inference script
- update food image analysis flow to call the CV model before falling back to the prompt
- document the new computer vision model in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9568ccd083269161ddad948d09c6