### PR TITLE
Fix YAML syntax in ML pipeline workflow

### DIFF
--- a/.github/workflows/ml_pipeline.yml
+++ b/.github/workflows/ml_pipeline.yml
@@ -28,7 +28,7 @@ jobs:
             echo "drift=true" >> $GITHUB_OUTPUT
           fi
       - name: Train models if drift detected
-        if: "${{ steps.drift.outputs.drift == true }}"
+        if: steps.drift.outputs.drift == 'true'
         run: |
           python Backend/src_ai/forecasting/train_forecasting.py
           python Backend/src_ai/predictive-matching/train_model.py data/training/sample.csv


### PR DESCRIPTION
## Summary
- correct condition syntax in `ml_pipeline.yml`

## Testing
- `python3 - <<'PY'
import yaml;print('loaded')
PY` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6840cdf12c6083269250e85a75050075