### PR TITLE
Add model evaluation script

### DIFF
--- a/.github/workflows/ml_pipeline.yml
+++ b/.github/workflows/ml_pipeline.yml
@@ -34,4 +34,4 @@ jobs:
           python Backend/src_ai/predictive-matching/train_model.py data/training/sample.csv
       - name: Evaluate models
         run: |
-          echo "TODO: Add evaluation scripts"
+          python Backend/src_ai/forecasting/evaluate_models.py

--- a/Backend/src_ai/forecasting/evaluate_models.py
+++ b/Backend/src_ai/forecasting/evaluate_models.py
@@ -1,0 +1,104 @@
+import os
+from datetime import datetime
+from typing import List, Tuple
+
+import pandas as pd
+from google.cloud import firestore
+from prophet import Prophet
+from sklearn.metrics import mean_absolute_error, accuracy_score
+import tensorflow as tf
+
+# Paths for predictive matching model
+default_data_path = os.getenv("PREDICT_EVAL_DATA", "data/training/sample.csv")
+default_model_path = os.getenv("PREDICT_MODEL_PATH", "volunteer_accept_model.h5")
+
+FORECAST_DONATIONS_COLLECTION = os.getenv("FORECAST_DONATIONS_COLLECTION", "donations")
+FORECAST_REQUESTS_COLLECTION = os.getenv("FORECAST_REQUESTS_COLLECTION", "requests")
+FORECAST_DAYS = int(os.getenv("FORECAST_DAYS", "7"))
+
+FORECAST_MAE_THRESHOLD = float(os.getenv("FORECAST_MAE_THRESHOLD", "10"))
+PREDICT_ACC_THRESHOLD = float(os.getenv("PREDICT_ACC_THRESHOLD", "0.5"))
+
+PREDICT_FEATURES = [
+    "successful_pickups",
+    "declined_pickups",
+    "avg_distance_km",
+    "days_since_last_pickup",
+    "distance_km",
+    "is_perishable",
+    "requested_hour",
+]
+
+def _load_time_series(client: firestore.Client, collection: str) -> pd.DataFrame:
+    docs = client.collection(collection).stream()
+    rows: List[dict] = []
+    for doc in docs:
+        data = doc.to_dict()
+        ts = data.get("timestamp") or data.get("createdAt") or data.get("date")
+        if not ts:
+            continue
+        if isinstance(ts, datetime):
+            dt = ts
+        else:
+            dt = datetime.fromisoformat(str(ts))
+        rows.append({"ds": dt.date(), "y": 1})
+    df = pd.DataFrame(rows)
+    if df.empty:
+        return pd.DataFrame(columns=["ds", "y"])
+    df = df.groupby("ds").sum().reset_index()
+    return df
+
+def _train_model(df: pd.DataFrame) -> Prophet:
+    model = Prophet()
+    if not df.empty:
+        model.fit(df)
+    return model
+
+def _forecast(model: Prophet, periods: int) -> pd.DataFrame:
+    future = model.make_future_dataframe(periods=periods)
+    forecast = model.predict(future)
+    return forecast[["ds", "yhat"]].tail(periods)
+
+def evaluate_forecast(client: firestore.Client, collection: str) -> float:
+    df = _load_time_series(client, collection)
+    if len(df) <= FORECAST_DAYS:
+        return float("inf")
+    df = df.sort_values("ds")
+    train_df = df.iloc[:-FORECAST_DAYS]
+    test_df = df.iloc[-FORECAST_DAYS:]
+    model = _train_model(train_df)
+    preds = _forecast(model, FORECAST_DAYS)
+    mae = mean_absolute_error(test_df["y"], preds["yhat"])
+    return mae
+
+def evaluate_predictive(data_path: str, model_path: str) -> float:
+    df = pd.read_csv(data_path)
+    X = df[PREDICT_FEATURES]
+    y = df["accepted"]
+    model = tf.keras.models.load_model(model_path)
+    preds = (model.predict(X, verbose=0).flatten() > 0.5).astype(int)
+    acc = accuracy_score(y, preds)
+    return acc
+
+def main() -> None:
+    data_path = default_data_path
+    model_path = default_model_path
+    client = firestore.Client()
+
+    donation_mae = evaluate_forecast(client, FORECAST_DONATIONS_COLLECTION)
+    request_mae = evaluate_forecast(client, FORECAST_REQUESTS_COLLECTION)
+    predict_acc = evaluate_predictive(data_path, model_path)
+
+    print(f"Donation forecast MAE: {donation_mae:.4f}")
+    print(f"Request forecast MAE: {request_mae:.4f}")
+    print(f"Predictive matching accuracy: {predict_acc:.4f}")
+
+    if (
+        donation_mae > FORECAST_MAE_THRESHOLD
+        or request_mae > FORECAST_MAE_THRESHOLD
+        or predict_acc < PREDICT_ACC_THRESHOLD
+    ):
+        raise SystemExit("Model metrics did not meet required thresholds")
+
+if __name__ == "__main__":
+    main()

--- a/docs/ml_pipeline_setup.md
+++ b/docs/ml_pipeline_setup.md
@@ -32,4 +32,11 @@ This document explains how to reproduce the machine learning workflows locally o
    python Backend/src_ai/predictive-matching/train_model.py <path-to-training-csv>
    ```
 
+5. **Evaluate trained models**
+   ```bash
+   python Backend/src_ai/forecasting/evaluate_models.py
+   ```
+
+   Customize thresholds with the `FORECAST_MAE_THRESHOLD` and `PREDICT_ACC_THRESHOLD` environment variables if needed.
+
 These steps mirror the automation performed in `.github/workflows/ml_pipeline.yml` so contributors can reproduce the pipeline locally.


### PR DESCRIPTION
## Summary
- implement `evaluate_models.py` to calculate forecasting MAE and predictive model accuracy
- run the evaluator from the ML pipeline workflow
- document how to run the evaluator locally

## Testing
- `python Backend/src_ai/monitoring/check_drift.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python Backend/src_ai/forecasting/evaluate_models.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6840cf85f8888326a87d99bd76e18e91