### PR TITLE
Fix CI workflow condition

### DIFF
--- a/.github/workflows/ml_pipeline.yml
+++ b/.github/workflows/ml_pipeline.yml
@@ -28,7 +28,7 @@ jobs:
             echo "drift=true" >> $GITHUB_OUTPUT
           fi
       - name: Train models if drift detected
-        if: steps.drift.outputs.drift == 'true'
+        if: ${{ steps.drift.outputs.drift == 'true' }}
         run: |
           python Backend/src_ai/forecasting/train_forecasting.py
           python Backend/src_ai/predictive-matching/train_model.py data/training/sample.csv


### PR DESCRIPTION
## Summary
- fix the drift check conditional in `ml_pipeline.yml` to use GitHub Actions expression syntax

## Testing
- `npm test` *(fails: could not read package.json)*
- `npm test` in `Frontend` *(fails: jest not found)*
- `npm test` in `Backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cc1189a083268f5a6d6be216f237