### PR TITLE
Fix quoting in ml pipeline

### DIFF
--- a/.github/workflows/ml_pipeline.yml
+++ b/.github/workflows/ml_pipeline.yml
@@ -28,7 +28,7 @@ jobs:
             echo "drift=true" >> $GITHUB_OUTPUT
           fi
       - name: Train models if drift detected
-        if: ${{ steps.drift.outputs.drift == 'true' }}
+        if: "${{ steps.drift.outputs.drift == 'true' }}"
         run: |
           python Backend/src_ai/forecasting/train_forecasting.py
           python Backend/src_ai/predictive-matching/train_model.py data/training/sample.csv


### PR DESCRIPTION
## Summary
- quote the drift check expression in the ml pipeline workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840d30a52148326a358e369a75048de